### PR TITLE
feat: Add compatibility with BuyEmAll v4+

### DIFF
--- a/Gui/MerchantFrame.lua
+++ b/Gui/MerchantFrame.lua
@@ -31,7 +31,6 @@ do -- [[ Set some permanent MerchantFrame changes ]]
 	MerchantNextPageButton:SetPoint("BOTTOMRIGHT", KrowiEVU_BottomExtensionRightBorder, "TOPRIGHT", -7, -5);
 
 	MerchantFrame.FilterDropdown:Hide();
-	-- MerchantFrameLootFilter:SetPoint("TOPRIGHT", MerchantFrame, -150, -28);
 
 	MerchantMoneyInset:SetPoint("TOPLEFT", MerchantFrame, "BOTTOMRIGHT", -169, 27);
 	-- <Anchor point="BOTTOMRIGHT" relativePoint="BOTTOMRIGHT" x="-5" y="4"/>

--- a/Gui/MerchantItemsContainer.lua
+++ b/Gui/MerchantItemsContainer.lua
@@ -31,7 +31,7 @@ local function ItemSlotOnEnter(button)
 	end
 end
 
-local function SetOnEnter(frame)
+function merchantItemsContainer:SetOnEnter(frame)
     frame:SetScript("OnEnter", ItemSlotOnEnter);
     frame.UpdateTooltip = ItemSlotOnEnter;
 end
@@ -39,7 +39,7 @@ end
 local infoNumRows, infoNumColumns = 0, 0;
 local itemSlotTable = {};
 for i = 1, 12, 1 do
-    SetOnEnter(_G["MerchantItem" .. i].ItemButton);
+    merchantItemsContainer:SetOnEnter(_G["MerchantItem" .. i].ItemButton);
 	tinsert(itemSlotTable, _G["MerchantItem" .. i]);
 end
 
@@ -49,12 +49,12 @@ function merchantItemsContainer:HideAll()
 	end
 end
 
-local function GetItemSlot(index)
+function merchantItemsContainer:GetItemSlot(index)
 	if itemSlotTable[index] then
 		return itemSlotTable[index];
 	end
 	local frame = CreateFrame("Frame", "MerchantItem" .. index, MerchantFrame, "MerchantItemTemplate");
-    SetOnEnter(frame.ItemButton);
+    merchantItemsContainer:SetOnEnter(frame.ItemButton);
 	itemSlotTable[index] = frame;
 	return frame;
 end
@@ -65,7 +65,7 @@ function merchantItemsContainer:LoadMaxNumItemSlots()
     local maxNumItems = maxNumRows * maxNumColumns;
     if #itemSlotTable < maxNumItems then
         for i = 1, maxNumItems, 1 do
-            local itemSlot = GetItemSlot(i);
+            local itemSlot = self:GetItemSlot(i);
             itemSlot:Hide();
         end
     end
@@ -93,7 +93,7 @@ hooksecurefunc(MerchantFrame.FilterDropdown, "Update", function()
 end);
 
 function merchantItemsContainer:DrawItemSlot(index, row, column, offsetX, offsetY)
-    local itemSlot = GetItemSlot(index);
+    local itemSlot = self:GetItemSlot(index);
     local calculatedOffsetX = self.FirstOffsetX + (column - 1) * (offsetX + self.ItemWidth);
     local calculatedOffsetY = self.FirstOffsetY - (row - 1) * (offsetY + self.ItemHeight);
     itemSlot:ClearAllPoints();

--- a/Krowi_ExtendedVendorUI.lua
+++ b/Krowi_ExtendedVendorUI.lua
@@ -20,7 +20,7 @@ function loadHelper:OnEvent(event, arg1, arg2)
             addon.Plugins:InjectOptions();
             addon.Options:Load(true);
 
-            addon.Plugins:Load();
+            addon.Plugins:OnInitialize();
 
             addon.Gui.MerchantItemsContainer:LoadMaxNumItemSlots();
 

--- a/Krowi_ExtendedVendorUI.toc
+++ b/Krowi_ExtendedVendorUI.toc
@@ -25,6 +25,7 @@ Libs\Files.xml
 API.lua
 
 Plugins\Files.xml
+Plugins\OnInitialize\Files.xml
 
 Localization\Files.xml
 
@@ -37,3 +38,5 @@ Icon.lua
 Filters.lua
 
 Gui\Files.xml
+
+Plugins\AfterAddonLoaded\Files.xml

--- a/Localization/enUS.Plugins.lua
+++ b/Localization/enUS.Plugins.lua
@@ -9,3 +9,8 @@ L["Can I Mog It"] = true
 L["Can I Mog It Desc"] = [=[This plugin fixes the overlay icons on vendor items when different filters are applied.
 
 There are no options.]=]
+
+L["BuyEmAll"] = true
+L["BuyEmAll Desc"] = [=[This plugin enhances the shift-click interface at vendors to allow buying items in bulk beyond what the game would otherwise allow.
+
+There are no options.]=]

--- a/Plugins/AfterAddonLoaded/BuyEmAll.lua
+++ b/Plugins/AfterAddonLoaded/BuyEmAll.lua
@@ -1,0 +1,167 @@
+local _, addon = ...;
+local plugins = addon.Plugins;
+plugins.BuyEmAll = {};
+local buyEmAll = plugins.BuyEmAll;
+
+local MerchantItemsContainer = addon.Gui.MerchantItemsContainer;
+tinsert(plugins.Plugins, buyEmAll);
+
+local function MoveFrameToBuyEmAllFrame(frame)
+  frame:SetParent(BuyEmAllFrame);
+  local point, _, relativePoint, offsetX, offsetY = frame:GetPoint();
+  frame:SetPoint(point, BuyEmAllFrame, relativePoint, offsetX, offsetY);
+end
+
+local function ModifyBuyEmAllFrame()
+  BuyEmAllFrameBottomLeftBorder:SetSize(256, 61);
+	BuyEmAllFrameBottomLeftBorder:SetTexture("Interface/MerchantFrame/Merchant");
+	BuyEmAllFrameBottomLeftBorder:SetTexCoord(0.001953125, 0.5, 0.00390625, 0.2421875);
+	BuyEmAllFrameBottomLeftBorder:SetPoint("BOTTOMLEFT", BuyEmAllFrame, "BOTTOMLEFT", 1, 26);
+
+	local bottomExtensionRightBorder = BuyEmAllFrame:CreateTexture("KrowiEVU_BuyEmAll_BottomExtensionRightBorder");
+	bottomExtensionRightBorder:SetSize(78, 61);
+	bottomExtensionRightBorder:SetTexture("Interface/MerchantFrame/Merchant");
+	bottomExtensionRightBorder:SetTexCoord(0.5, 0.650390625, 0.00390625, 0.2421875);
+	bottomExtensionRightBorder:SetPoint("BOTTOMRIGHT", BuyEmAllFrame, "BOTTOMRIGHT", -1, 26);
+
+	local bottomExtensionLeftBorder = BuyEmAllFrame:CreateTexture("KrowiEVU_BuyEmAll_BottomExtensionLeftBorder");
+	bottomExtensionLeftBorder:SetSize(78, 61);
+	bottomExtensionLeftBorder:SetTexture("Interface/MerchantFrame/Merchant");
+	bottomExtensionLeftBorder:SetTexCoord(0.240234375, 0.390625, 0.00390625, 0.2421875);
+	bottomExtensionLeftBorder:SetPoint("TOPLEFT", BuyEmAllFrameBottomLeftBorder, "TOPRIGHT", 0, 0);
+
+	local bottomExtensionMidBorder = BuyEmAllFrame:CreateTexture("KrowiEVU_BuyEmAll_BottomExtensionMidBorder");
+	bottomExtensionMidBorder:SetTexture("Interface/MerchantFrame/Merchant");
+	bottomExtensionMidBorder:SetTexCoord(0.01953125, 0.373046875, 0.00390625, 0.2421875);
+	bottomExtensionMidBorder:SetPoint("TOPLEFT", bottomExtensionLeftBorder, "TOPRIGHT", 0, 0);
+	bottomExtensionMidBorder:SetPoint("BOTTOMRIGHT", bottomExtensionRightBorder, "BOTTOMLEFT", 0, 0);
+
+	BuyEmAllPrevPageButton:SetPoint("BOTTOMLEFT", BuyEmAllFrameBottomLeftBorder, "TOPLEFT", 8, -5);
+	BuyEmAllNextPageButton:SetPoint("BOTTOMRIGHT", KrowiEVU_BuyEmAll_BottomExtensionRightBorder, "TOPRIGHT", -7, -5);
+
+  BuyEmAllFrame.FilterDropdown:Hide();
+
+	BuyEmAllMoneyInset:SetPoint("TOPLEFT", BuyEmAllFrame, "BOTTOMRIGHT", -169, 27);
+	BuyEmAllExtraCurrencyInset:ClearAllPoints();
+	BuyEmAllExtraCurrencyInset:SetPoint("BOTTOMRIGHT", -167, 4);
+	BuyEmAllExtraCurrencyInset:SetPoint("TOPLEFT", BuyEmAllFrame, "BOTTOMRIGHT", -332, 27);
+	BuyEmAllExtraCurrencyBg:ClearAllPoints();
+	BuyEmAllExtraCurrencyBg:SetPoint("TOPRIGHT", BuyEmAllExtraCurrencyInset, -3, -2);
+	BuyEmAllExtraCurrencyBg:SetPoint("BOTTOMLEFT", BuyEmAllExtraCurrencyInset, 3, 2);
+end
+
+local itemSlotTable = {};
+
+local function GetItemSlot(index)
+  if itemSlotTable[index] then
+    return itemSlotTable[index];
+  end
+  local frame = CreateFrame("Frame", "BuyEmAllItem" .. index, BuyEmAllFrame, "MerchantItemTemplate");
+  MerchantItemsContainer:SetOnEnter(frame.ItemButton);
+  itemSlotTable[index] = frame;
+  return frame;
+end
+
+function buyEmAll.AfterLoad()
+  for i = 1, 12, 1 do
+    MerchantItemsContainer:SetOnEnter(_G["BuyEmAllItem" .. i].ItemButton);
+    tinsert(itemSlotTable, _G["BuyEmAllItem" .. i]);
+  end
+
+  ModifyBuyEmAllFrame();
+  MoveFrameToBuyEmAllFrame(KrowiEVU_OptionsButton);
+  MoveFrameToBuyEmAllFrame(KrowiEVU_FilterButton);
+  MoveFrameToBuyEmAllFrame(KrowiEVU_SearchBox);
+
+  hooksecurefunc('BuyEmAllFrame_UpdateMerchantInfo', function()
+    BuyEmAllFrame:SetSize(MerchantFrame:GetSize())
+    if(KrowiEVU_BottomExtensionLeftBorder:IsShown()) then
+      KrowiEVU_BuyEmAll_BottomExtensionLeftBorder:Show()
+    else
+      KrowiEVU_BuyEmAll_BottomExtensionLeftBorder:Hide()
+    end
+
+    if(KrowiEVU_BottomExtensionMidBorder:IsShown()) then
+      KrowiEVU_BuyEmAll_BottomExtensionMidBorder:Show()
+    else
+      KrowiEVU_BuyEmAll_BottomExtensionMidBorder:Hide()
+    end
+
+    KrowiEVU_BuyEmAll_BottomExtensionRightBorder:Show();
+  end)
+
+  hooksecurefunc('BuyEmAllFrame_UpdateBuybackInfo', function()
+    BuyEmAllFrame:SetSize(MerchantFrame:GetSize())
+    KrowiEVU_BuyEmAll_BottomExtensionLeftBorder:Hide();
+    KrowiEVU_BuyEmAll_BottomExtensionMidBorder:Hide();
+    KrowiEVU_BuyEmAll_BottomExtensionRightBorder:Hide();
+  end)
+
+  hooksecurefunc("BuyEmAllFrame_UpdateRepairButtons", function()
+    if not CanMerchantRepair() then
+      local point, _, relativePoint, offsetX, offsetY = MerchantSellAllJunkButton:GetPoint();
+      BuyEmAllSellAllJunkButton:SetPoint(point, BuyEmAllFrame, relativePoint, offsetX, offsetY);
+    end
+  end);
+
+  hooksecurefunc("BuyEmAllFrame_UpdateMerchantInfo", function()
+    MerchantItemsContainer:DrawForMerchantInfo();
+  end);
+
+  hooksecurefunc(MerchantItemsContainer, 'GetItemSlot', function(_, index)
+    GetItemSlot(index);
+  end)
+
+  hooksecurefunc(MerchantItemsContainer, 'DrawMerchantBuyBackItem', function(_, show)
+    if show then
+      local point, _, relativePoint, offsetX, offsetY = MerchantBuyBackItem:GetPoint();
+      BuyEmAllBuyBackItem:ClearAllPoints();
+      BuyEmAllBuyBackItem:SetPoint(point, BuyEmAllFrameBottomLeftBorder, relativePoint, offsetX, offsetY);
+      BuyEmAllBuyBackItem:Show();
+    else
+      BuyEmAllBuyBackItem:Hide();
+    end
+  end)
+
+  hooksecurefunc(MerchantItemsContainer, 'DrawItemSlots', function()
+    for i = 1, MERCHANT_ITEMS_PER_PAGE do
+      local itemSlot = GetItemSlot(i);
+      local originalItemSlot = MerchantItemsContainer:GetItemSlot(i);
+      local point, relativeTo, relativePoint, offsetX, offsetY = originalItemSlot:GetPoint();
+
+      print(itemSlot:GetName(), itemSlot:GetPoint())
+      print(originalItemSlot:GetName(), originalItemSlot:GetPoint())
+      print(point, relativePoint, offsetX, offsetY);
+
+      itemSlot:ClearAllPoints();
+      itemSlot:SetPoint(point, BuyEmAllFrame, relativePoint, offsetX, offsetY);
+      itemSlot:Show();
+    end
+  end)
+
+  hooksecurefunc(MerchantItemsContainer, 'HideRemainingItemSlots', function(_, startIndex)
+    local numItemSlots = #itemSlotTable;
+    for i = startIndex, numItemSlots, 1 do
+        itemSlotTable[i]:Hide();
+    end
+  end)
+
+  hooksecurefunc(BuyEmAllFrame.FilterDropdown, "Update", function()
+    MerchantItemsContainer:PrepareInfo();
+  end);
+end
+
+function buyEmAll.OnAddonLoaded() 
+  local addonEnabled, addonLoaded = C_AddOns.IsAddOnLoaded('BuyEmAll');
+  if(not addonEnabled) then return end
+  if(not addonLoaded) then
+    local loadFrame = CreateFrame('Frame');
+    loadFrame:RegisterEvent('ADDON_LOADED');
+    function loadFrame:OnEvent(_, addonName)
+      if(addonName == 'BuyEmAll') then buyEmAll.AfterLoad() end
+    end
+    loadFrame:SetScript('OnEvent', loadFrame.OnEvent);
+  else
+    buyEmAll.AfterLoad();
+  end
+end

--- a/Plugins/AfterAddonLoaded/BuyEmAll.lua
+++ b/Plugins/AfterAddonLoaded/BuyEmAll.lua
@@ -129,10 +129,6 @@ function buyEmAll.AfterLoad()
       local originalItemSlot = MerchantItemsContainer:GetItemSlot(i);
       local point, relativeTo, relativePoint, offsetX, offsetY = originalItemSlot:GetPoint();
 
-      print(itemSlot:GetName(), itemSlot:GetPoint())
-      print(originalItemSlot:GetName(), originalItemSlot:GetPoint())
-      print(point, relativePoint, offsetX, offsetY);
-
       itemSlot:ClearAllPoints();
       itemSlot:SetPoint(point, BuyEmAllFrame, relativePoint, offsetX, offsetY);
       itemSlot:Show();

--- a/Plugins/AfterAddonLoaded/BuyEmAll.lua
+++ b/Plugins/AfterAddonLoaded/BuyEmAll.lua
@@ -56,7 +56,7 @@ local function GetItemSlot(index)
   if itemSlotTable[index] then
     return itemSlotTable[index];
   end
-  local frame = CreateFrame("Frame", "BuyEmAllItem" .. index, BuyEmAllFrame, "MerchantItemTemplate");
+  local frame = CreateFrame("Frame", "BuyEmAllItem" .. index, BuyEmAllFrame, "BuyEmAllItemTemplate");
   MerchantItemsContainer:SetOnEnter(frame.ItemButton);
   itemSlotTable[index] = frame;
   return frame;

--- a/Plugins/AfterAddonLoaded/Files.xml
+++ b/Plugins/AfterAddonLoaded/Files.xml
@@ -1,0 +1,4 @@
+<Ui>
+    <Script file="BuyEmAll.lua" />
+    <Script file="onAddonLoaded.lua" />
+</Ui>

--- a/Plugins/AfterAddonLoaded/onAddonLoaded.lua
+++ b/Plugins/AfterAddonLoaded/onAddonLoaded.lua
@@ -1,0 +1,4 @@
+local _, addon = ...;
+local plugins = addon.Plugins;
+
+plugins:OnAddonLoaded();

--- a/Plugins/Files.xml
+++ b/Plugins/Files.xml
@@ -1,4 +1,3 @@
 <Ui>
     <Script file="Plugins.lua" />
-    <Script file="CanIMogIt.lua" />
 </Ui>

--- a/Plugins/OnInitialize/CanIMogIt.lua
+++ b/Plugins/OnInitialize/CanIMogIt.lua
@@ -1,0 +1,21 @@
+local _, addon = ...;
+local plugins = addon.Plugins;
+plugins.CanIMogIt = {};
+local canIMogIt = plugins.CanIMogIt;
+tinsert(plugins.Plugins, canIMogIt);
+
+function canIMogIt.OnInitialize()
+    if MerchantFrame_CIMIOnClick then
+        hooksecurefunc("MerchantFrame_SetFilter", function()
+            C_Timer.After(0.1, function()
+                MerchantFrame_CIMIOnClick();
+            end);
+        end);
+    end
+end
+
+function canIMogIt.InjectOptions()
+    addon.InjectOptions:AddPluginTable("CanIMogIt", addon.L["Can I Mog It"], addon.L["Can I Mog It Desc"]:K_ReplaceVars(addon.L["Can I Mog It"]), function()
+        return C_AddOns.IsAddOnLoaded("CanIMogIt");
+    end);
+end

--- a/Plugins/OnInitialize/Files.xml
+++ b/Plugins/OnInitialize/Files.xml
@@ -1,0 +1,3 @@
+<Ui>
+    <Script file="CanIMogIt.lua" />
+</Ui>

--- a/Plugins/Plugins.lua
+++ b/Plugins/Plugins.lua
@@ -29,10 +29,18 @@ function plugins:InjectOptions()
     end
 end
 
-function plugins:Load()
+function plugins:OnInitialize()
     for _, plugin in next, self.Plugins do
-        if type(plugin.Load) == "function" then
-            plugin.Load();
+        if type(plugin.OnInitialize) == "function" then
+            plugin.OnInitialize();
+        end
+    end
+end
+
+function plugins:OnAddonLoaded()
+    for _, plugin in next, self.Plugins do
+        if type(plugin.OnAddonLoaded) == "function" then
+            plugin.OnAddonLoaded();
         end
     end
 end


### PR DESCRIPTION
In this PR, I've added compatibility with the BuyEmAllFrame which is new in BuyEmAll version 4 and later. 

I've done this using the plugin architecture already present in the addon. when both _Krowi's Extended Vendor UI_ and _BuyemAll_ are loaded, the BuyEmAll plugin moves the UI frames owned by this addon from _MerchantFrame_ to  _BuyEmAllFrame_, and uses _postsecurehook_ in order to sync changes made to the MerchantFrame over to the BuyEmAllFrame.

I had to make a few minor edits to make this work:

- I split the plugins into _OnInitialize_ and _AfterAddonLoaded_ plugins. _AfterAddonLoaded_ plugins are ran last, after all the other files have been initialised. This is necessary for the BuyEmAll plugin to hook into the _MerchantItemsContainer_. The 'Can I mog It' addon is an _OnInitialize_ addon and is ran at the same step during initialisation as it was in the past.
- I changed the _GetItemSlot_ and _SetOnEnter_ functions in the _MerchantItemsContainer_ from local to table functions. This is necessary for the _BuyEmAll_ plugin to hook the _GetItemSlot_ function so it can also make new item buttons for the _BuyEmAllFrame_.