### PR TITLE
Update interface & add category to TOC

### DIFF
--- a/Krowi_ExtendedVendorUI.toc
+++ b/Krowi_ExtendedVendorUI.toc
@@ -1,4 +1,4 @@
-## Interface: 110005
+## Interface: 110100
 ## Title: Krowi's |cFF1D92C2Extended Vendor UI|r
 ## X-Prefix: KrowiEVU
 ## X-Acronym: KEVU
@@ -19,6 +19,18 @@
 ## X-Wago-Project-ID: mNwQwWKo
 ## X-WoWInterface: https://www.wowinterface.com/downloads/info26611-KrowisExtendedVendorUI
 ## X-WoWInterface-Project-ID: 26611
+
+## Category-enUS: Inventory
+## Category-deDE: Inventar
+## Category-esES: Inventario
+## Category-esMX: Inventario
+## Category-frFR: Inventaire
+## Category-itIT: Inventario
+## Category-koKR: 소지품
+## Category-ptBR: Inventário
+## Category-ruRU: Предметы
+## Category-zhCN: 物品栏
+## Category-zhTW: 物品欄
 
 Libs\Files.xml
 


### PR DESCRIPTION
Since Patch 11.1, it is possible to categorize an addon and group them. More info: https://warcraft.wiki.gg/wiki/Patch_11.1.0/API_changes

I think the “Inventory” category is the most suitable. What do you think?