### PR TITLE
Expanding "Hide Collected - Appearances" logic

### DIFF
--- a/Filters.lua
+++ b/Filters.lua
@@ -292,7 +292,50 @@ do -- Transmog
 	end
 
 	function filters.IsTransmogCollected(itemId)
-		return C_TransmogCollection.PlayerHasTransmog(itemId)
+			-- If this exact item/source is known
+			if C_TransmogCollection.PlayerHasTransmog(itemId) then
+					return true
+			end
+
+			-- Try to obtain the sourceID from C_TransmogCollection.GetItemInfo
+			local first, second = C_TransmogCollection.GetItemInfo(itemId)
+			local sourceID = second
+			if type(first) == 'table' then
+					-- table form may include the source info under known keys
+					sourceID = sourceID or first.sourceID or first.itemModifiedAppearanceID or first.modifiedAppearanceID
+			end
+
+			-- If we have a sourceID, get the appearanceID via GetAppearanceSourceInfo
+			local appearanceID
+			if sourceID then
+					local appearanceInfo = C_TransmogCollection.GetAppearanceSourceInfo(sourceID)
+					appearanceID = appearanceInfo and (appearanceInfo.itemAppearanceID or appearanceInfo.appearanceID)
+			end
+
+			-- fallback: if GetItemInfo returned an appearanceID directly in the second position
+			if not appearanceID then
+					-- sometimes the return values can be (appearanceID, <other>) — try those
+					if type(first) == 'number' then
+							appearanceID = first
+					elseif type(second) == 'number' then
+							appearanceID = second
+					end
+			end
+
+			if not appearanceID then
+					return false
+			end
+
+			local sourceIDs = C_TransmogCollection.GetAllAppearanceSources(appearanceID)
+			if sourceIDs then
+					for _, src in ipairs(sourceIDs) do
+							if C_TransmogCollection.PlayerHasTransmogItemModifiedAppearance(src) then
+									return true
+							end
+					end
+			end
+
+			return false
 	end
 end
 

--- a/Gui/MerchantItemsContainer.lua
+++ b/Gui/MerchantItemsContainer.lua
@@ -18,9 +18,16 @@ merchantItemsContainer.ItemWidth, merchantItemsContainer.ItemHeight = MerchantIt
 local function ItemSlotOnEnter(button)
 	GameTooltip:SetOwner(button, 'ANCHOR_RIGHT')
 	if MerchantFrame.selectedTab == 1 then
-		GameTooltip:SetMerchantItem(addon.CachedItemIndices[button:GetID()])
-		GameTooltip_ShowCompareItem(GameTooltip)
-		MerchantFrame.itemHover = button:GetID()
+			local realIndex = addon.CachedItemIndices[button:GetID()]
+			-- avoid passing nil/0 to C_TooltipInfo.GetMerchantItem (causes bad argument error)
+			if realIndex and realIndex > 0 then
+					GameTooltip:SetMerchantItem(realIndex)
+					GameTooltip_ShowCompareItem(GameTooltip)
+					MerchantFrame.itemHover = button:GetID()
+			else
+					-- nothing valid to show for this display slot
+					return
+			end
 	else
 		GameTooltip:SetBuybackItem(button:GetID())
 		if IsModifiedClick('DRESSUP') and button.hasItem then


### PR DESCRIPTION
Right now the addon matches the itemID appearance. This changes make it also check appearanceInfo to hide items which appeareance you already know (but from another item).