### PR TITLE
fix: guard against nil index in ItemSlotOnEnter tooltip call

### DIFF
--- a/Gui/MerchantItemsContainer.lua
+++ b/Gui/MerchantItemsContainer.lua
@@ -18,7 +18,9 @@ merchantItemsContainer.ItemWidth, merchantItemsContainer.ItemHeight = MerchantIt
 local function ItemSlotOnEnter(button)
 	GameTooltip:SetOwner(button, 'ANCHOR_RIGHT')
 	if MerchantFrame.selectedTab == 1 then
-		GameTooltip:SetMerchantItem(addon.CachedItemIndices[button:GetID()])
+		local index = addon.CachedItemIndices[button:GetID()]
+		if not index then return end
+		GameTooltip:SetMerchantItem(index)
 		GameTooltip_ShowCompareItem(GameTooltip)
 		MerchantFrame.itemHover = button:GetID()
 	else


### PR DESCRIPTION
When merchant items are filtered, CachedItemIndices may not have an entry for every visible item slot. Hovering over an empty slot passes nil to GameTooltip:SetMerchantItem(), which causes a Lua error in C_TooltipInfo.GetMerchantItem(). Add a nil check to bail out early.