### PR TITLE
Update Classic Era and TBC interface versions

### DIFF
--- a/Krowi_ExtendedVendorUI.toc
+++ b/Krowi_ExtendedVendorUI.toc
@@ -1,4 +1,4 @@
-## Interface: 120007, 50504, 20505, 11508
+## Interface: 120007, 50504, 20506, 11509
 ## Title: Krowi's |cFF1D92C2Extended Vendor UI|r
 ## X-Prefix: KrowiEVU
 ## X-Acronym: KEVU


### PR DESCRIPTION
## Summary

Update the existing Classic Era and TBC interface entries to the current client versions:

- Classic Era: `11509`
- TBC: `20506`

No Lua code or other client metadata is changed.

## Verification

- preserves the existing Retail `120007` and Mists `50504` entries
- changes only the first line of `Krowi_ExtendedVendorUI.toc`
- `git diff --check` passes